### PR TITLE
Fix model cast

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,2 @@
+
+- Abhash Jha

--- a/nasbench_pytorch/model/model.py
+++ b/nasbench_pytorch/model/model.py
@@ -149,7 +149,8 @@ class Cell(nn.Module):
 
                 # perform operation on node
                 #vertex_input = torch.stack(fan_in, dim=0).sum(dim=0)
-                vertex_input = torch.zeros(fan_in[0].shape).to(self.dev_param.device)
+                vertex_input = torch.zeros_like(fan_in[0]).to(self.dev_param.device)
+                
                 for val in fan_in:
                     vertex_input += val
                 #vertex_input = sum(fan_in)


### PR DESCRIPTION
I faced an issue when I tried to cast the model to double. It turns out that, at the [point](https://github.com/romulus0914/NASBench-PyTorch/blob/a36d7a7c6770079c35db3ad3b5d0aa139e1105a2/nasbench_pytorch/model/model.py#L152) when the variable `vertex_input` gets initialized as [`torch.zeros`](https://pytorch.org/docs/stable/generated/torch.zeros.html), the default data type is FloatTensor. Hence, when the model is cast to a data type other than FloatTensor, it fails due to this initialization, as it creates a mismatch between the input and the model's parameters.

It is thus safer to use [`torch.zeros_like`](https://pytorch.org/docs/stable/generated/torch.zeros_like.html) than [`torch.zeros`](https://pytorch.org/docs/stable/generated/torch.zeros.html). Specifically, the change that follows is:

**from** 
```python
vertex_input = torch.zeros(fan_in[0].shape).to(self.dev_param.device)
```

**to**

```python
vertex_input = torch.zeros_like(fan_in[0]).to(self.dev_param.device)
```